### PR TITLE
Fix the consumer so that it does not perform the json decoding of the message twice.

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -24,7 +24,7 @@ def consume(topic):
     logger.info("Reading Topic: %s", topic)
     while True:
         for data in consumer:
-            msg = json.loads(data.value)
+            msg = data.value
             platform_metadata = msg.get("platform_metadata")
             if platform_metadata:
                 request_id = platform_metadata.get("request_id", -1)


### PR DESCRIPTION
The KafkaConsumer was already configured to json decode the message.  I added another json decode due to a bug in the inventory mq service. This removes the double json decoding that I introduced.
